### PR TITLE
adjust willkg org

### DIFF
--- a/Foundational_Technology_Committee.md
+++ b/Foundational_Technology_Committee.md
@@ -4,7 +4,7 @@
 | Lucy Harris | Mozilla (Open Innovation) | 2019 - present |
 | Mike Hoye | Mozilla (Engineering Operations) | 2019 - present |
 | Emma Irwin | Mozilla (Open Innovation) | 2019 - present |
-| Will Kahn-Greene | Mozilla (Crash Ingestion) | 2019 - present |
+| Will Kahn-Greene | Mozilla (Engineering Operations) | 2019 - present |
 | Philip Lamb | Mozilla (Emerging Technologies) | 2019 - present |
 | Tom Ritter | Mozilla (Platform Engineering) | 2019 - present |
 | Laura Thomson | Mozilla (Engineering Operations) | 2019 - present |


### PR DESCRIPTION
Crash ingestion is part of engineering operations--it's not a separate organization in Mozilla.